### PR TITLE
Add support for synchronous Sentry calls [ch1191]

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,11 @@ reporting:
     dsn: https://public:secret@sentry.example.com/project
     tags:
       environment: production
+    wait: false
 ```
+
+Sentry calls are performed asynchronously by default. To wait for the Sentry
+API to acknowledge the event, set `wait: true`.
 
 ### Prefix
 

--- a/root.go
+++ b/root.go
@@ -29,7 +29,7 @@ func New(config Configuration) (*Reporter, error) {
 	}
 
 	// Initialize logger
-	l, err := logger.New(config.Logging, sentryHandler(s), config.Prefix)
+	l, err := logger.New(config.Logging, sentryHandler(s, config.Sentry.Wait), config.Prefix)
 	if err != nil {
 		return nil, err
 	}

--- a/sentry.go
+++ b/sentry.go
@@ -9,8 +9,10 @@ import (
 )
 
 // Interface Sentry with the logging subsytem. The idea is to register
-// an additional handler that will forward errors to Sentry.
-func sentryHandler(client *raven.Client) log.Handler {
+// an additional handler that will forward errors to Sentry. If wait is
+// true, calls to Sentry API will be done synchronously (and thus will
+// block the caller).
+func sentryHandler(client *raven.Client, wait bool) log.Handler {
 	if client == nil {
 		// No sentry configured
 		return nil
@@ -41,7 +43,12 @@ func sentryHandler(client *raven.Client) log.Handler {
 		if err == nil {
 			return nil
 		}
+
 		client.CaptureError(err, tags)
+		if wait {
+			client.Wait()
+		}
+
 		return nil
 	})
 }

--- a/sentry/config.go
+++ b/sentry/config.go
@@ -5,4 +5,5 @@ type Configuration struct {
 	DSN     string
 	Tags    map[string]string
 	Version string
+	Wait    bool
 }

--- a/sentry/config_test.go
+++ b/sentry/config_test.go
@@ -17,12 +17,23 @@ func TestUnmarshalConfiguration(t *testing.T) {
 			Configuration{
 				DSN:  "http://public:secret@sentry.errors",
 				Tags: nil,
+				Wait: false,
 			},
 		},
 		{"{}",
 			Configuration{
 				DSN:  "",
 				Tags: nil,
+				Wait: false,
+			},
+		},
+		{`
+dsn: http://public:secret@sentry.errors
+wait: true
+`,
+			Configuration{
+				DSN:  "http://public:secret@sentry.errors",
+				Wait: true,
 			},
 		},
 		{`
@@ -39,6 +50,7 @@ version: "foo"
 					"dc":          "us-east-4",
 				},
 				Version: "foo",
+				Wait:    false,
 			},
 		},
 	}


### PR DESCRIPTION
CH story: https://app.clubhouse.io/exoscale/story/1191/add-support-for-synchronous-sentry-calls-in-go-reporter