### PR TITLE
get fqdn in go since os.Hostname doesn't have it

### DIFF
--- a/config/fqdn.go
+++ b/config/fqdn.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Get Fully Qualified Domain Name
-// returns  hostanme-fqdn or error
+// returns the host FQDN or an error
 // Original idea from: https://github.com/Showmax/go-fqdn/blob/master/fqdn.go
 func GetFQDN() (string, error) {
 	hostname, err := os.Hostname()

--- a/config/fqdn.go
+++ b/config/fqdn.go
@@ -1,4 +1,4 @@
-package fqdn
+package config
 
 import (
 	"net"
@@ -9,7 +9,8 @@ import (
 
 // Get Fully Qualified Domain Name
 // returns  hostanme-fqdn or error
-func Get() (string, error) {
+// Original idea from: https://github.com/Showmax/go-fqdn/blob/master/fqdn.go
+func GetFQDN() (string, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return "unknown", errors.Wrapf(err, "hostname unknown")

--- a/fqdn/fqdn.go
+++ b/fqdn/fqdn.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Get Fully Qualified Domain Name
-// returns "unknown" or hostanme in case of error
+// returns  hostanme-fqdn or error
 func Get() (string, error) {
 	hostname, err := os.Hostname()
 	if err != nil {

--- a/fqdn/fqdn.go
+++ b/fqdn/fqdn.go
@@ -1,0 +1,38 @@
+package fqdn
+
+import (
+	"net"
+	"os"
+	"strings"
+        "github.com/pkg/errors"
+)
+
+// Get Fully Qualified Domain Name
+// returns "unknown" or hostanme in case of error
+func Get() (string, error) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "unknown", errors.Wrapf(err, "hostname unknown")
+	}
+
+	addrs, err := net.LookupIP(hostname)
+	if err != nil {
+		return hostname, nil
+	}
+
+	for _, addr := range addrs {
+		if ipv4 := addr.To4(); ipv4 != nil {
+			ip, err := ipv4.MarshalText()
+			if err != nil {
+				return hostname, nil
+			}
+			hosts, err := net.LookupAddr(string(ip))
+			if err != nil || len(hosts) == 0 {
+				return hostname, nil
+			}
+			fqdn := hosts[0]
+			return strings.TrimSuffix(fqdn, "."), nil // return fqdn without trailing dot
+		}
+	}
+	return hostname, nil
+}

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ collectd.org v0.3.0 h1:iNBHGw1VvPJxH2B6RiFWFZ+vsjo1lCdRszBeOuwGi00=
 collectd.org v0.3.0/go.mod h1:A/8DzQBkF6abtvrT2j/AU/4tiBgJWYyh0y/oB/4MlWE=
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448 h1:8tNk6SPXzLDnATTrWoI5Bgw9s/x4uf0kmBpk21NZgI4=
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
+github.com/exoscale/go-metrics v0.0.0-20180729161012-6a0b1c6c28ec h1:A4NuISi8rZso9vY8WWHv9IbruBMMi9hRVajfAqRtxT0=
 github.com/exoscale/go-metrics v0.0.0-20180729161012-6a0b1c6c28ec/go.mod h1:UzBqd2WjB5W7Uf7bOm1uOiYkXV7USjnD8Hy3nV2qZQM=
 github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=

--- a/metrics/collectd.go
+++ b/metrics/collectd.go
@@ -2,7 +2,6 @@ package metrics
 
 import (
 	"context"
-//	"os"
 	"path"
 	"strings"
 	"time"

--- a/metrics/collectd.go
+++ b/metrics/collectd.go
@@ -2,7 +2,7 @@ package metrics
 
 import (
 	"context"
-	"os"
+//	"os"
 	"path"
 	"strings"
 	"time"
@@ -12,7 +12,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rcrowley/go-metrics"
 
-	"github.com/exoscale/go-reporter/config"
+	"github.com/exoscale/go-reporter/fqdn"
+        "github.com/exoscale/go-reporter/config"
 )
 
 var separator = "."
@@ -74,7 +75,7 @@ func (c *CollectdConfiguration) initExporter(m *Metrics) error {
 func collectdReportOnce(r metrics.Registry, client *network.Client, interval time.Duration,
 	prefix string, excluded []string) {
 	ctx := context.Background()
-	hostname, err := os.Hostname()
+        hostname, err := fqdn.Get()
 	if err != nil {
 		return
 	}

--- a/metrics/collectd.go
+++ b/metrics/collectd.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rcrowley/go-metrics"
 
-	"github.com/exoscale/go-reporter/fqdn"
         "github.com/exoscale/go-reporter/config"
 )
 
@@ -74,7 +73,7 @@ func (c *CollectdConfiguration) initExporter(m *Metrics) error {
 func collectdReportOnce(r metrics.Registry, client *network.Client, interval time.Duration,
 	prefix string, excluded []string) {
 	ctx := context.Background()
-        hostname, err := fqdn.Get()
+        hostname, err := config.GetFQDN()
 	if err != nil {
 		return
 	}

--- a/metrics/collectd_test.go
+++ b/metrics/collectd_test.go
@@ -213,7 +213,7 @@ L:
 			continue
 		}
 
-		hostname, _ := os.Hostname()
+		hostname, _ := config.GetFQDN()
 		if v.Host != hostname {
 			t.Errorf("Received metric %+v has hostname == %v, expected %v",
 				v, v.Host, hostname)

--- a/metrics/collectd_test.go
+++ b/metrics/collectd_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
-	"os"
 	"testing"
 	"time"
 


### PR DESCRIPTION
Got the original idea from:
https://github.com/Showmax/go-fqdn/blob/master/fqdn.go
Not sure if we want this, but if that's the case, this could address [ch2744]