### PR TITLE
Pushgateway metrics

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,11 +1,12 @@
 package reporter
 
 import (
-	"gopkg.in/yaml.v2"
 	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
 
 	"github.com/exoscale/go-reporter/logger"
 	"github.com/exoscale/go-reporter/metrics"
+	"github.com/exoscale/go-reporter/pushgw"
 	"github.com/exoscale/go-reporter/sentry"
 )
 
@@ -14,6 +15,7 @@ type Configuration struct {
 	Logging logger.Configuration
 	Sentry  sentry.Configuration
 	Metrics metrics.Configuration
+	Pushgw  pushgw.Configuration
 	Prefix  string
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/exoscale/go-reporter/helpers"
 	"github.com/exoscale/go-reporter/logger"
 	"github.com/exoscale/go-reporter/metrics"
+	"github.com/exoscale/go-reporter/pushgw"
 	"github.com/exoscale/go-reporter/sentry"
 )
 
@@ -30,6 +31,12 @@ metrics:
       listen: :8123
 sentry:
   dsn: "http://public:secret@errors"
+pushgw:
+  url: https://pushgateway.net
+  job: bar
+  certfile: /tmp/foo
+  keyfile: /tmp/bar
+  cacertfile: /tmp/baz
 `,
 			want: Configuration{
 				Logging: logger.Configuration{
@@ -45,6 +52,13 @@ sentry:
 				}),
 				Sentry: sentry.Configuration{
 					DSN: "http://public:secret@errors",
+				},
+				Pushgw: pushgw.Configuration{
+					URL:        "https://pushgateway.net",
+					Job:        "bar",
+					CertFile:   "/tmp/foo",
+					KeyFile:    "/tmp/bar",
+					CacertFile: "/tmp/baz",
 				},
 				Prefix: "aargau",
 			},

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,6 @@ require (
 	github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.4 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.1.0
 	github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a
@@ -20,3 +18,5 @@ require (
 )
 
 replace github.com/rcrowley/go-metrics => github.com/exoscale/go-metrics v0.0.0-20180729161012-6a0b1c6c28ec
+
+go 1.13

--- a/pushgw/config.go
+++ b/pushgw/config.go
@@ -1,11 +1,10 @@
 package pushgw
 
 // Configuretation is config for push gateway
-// for grouping see https://github.com/prometheus/client_golang/blob/master/prometheus/push/push.go#L152
 type Configuration struct {
-	URL string
-	Job string
-	// CertFile   config.FilePath
-	// KeyFile    config.FilePath
-	// CacertFile config.FilePath
+	URL        string
+	Job        string
+	CertFile   string
+	KeyFile    string
+	CacertFile string
 }

--- a/pushgw/config.go
+++ b/pushgw/config.go
@@ -1,0 +1,11 @@
+package pushgw
+
+// Configuretation is config for push gateway
+// for grouping see https://github.com/prometheus/client_golang/blob/master/prometheus/push/push.go#L152
+type Configuration struct {
+	URL string
+	Job string
+	// CertFile   config.FilePath
+	// KeyFile    config.FilePath
+	// CacertFile config.FilePath
+}

--- a/pushgw/config_test.go
+++ b/pushgw/config_test.go
@@ -1,9 +1,10 @@
 package pushgw
 
 import (
+	"testing"
+
 	"github.com/exoscale/go-reporter/helpers"
 	"gopkg.in/yaml.v2"
-	"testing"
 )
 
 func TestUnmarshalConfiguration(t *testing.T) {
@@ -13,12 +14,18 @@ func TestUnmarshalConfiguration(t *testing.T) {
 	}{
 		{
 			in: `
-url: http://pushgateway.exoscale.net
+url: http://pushgateway.net
 job: bar
+certfile: /tmp/foo
+keyfile: /tmp/bar
+cacertfile: /tmp/baz
 `,
 			want: Configuration{
-				URL: "http://pushgateway.exoscale.net",
-				Job: "bar",
+				URL:        "http://pushgateway.net",
+				Job:        "bar",
+				CertFile:   "/tmp/foo",
+				KeyFile:    "/tmp/bar",
+				CacertFile: "/tmp/baz",
 			},
 		},
 	}

--- a/pushgw/config_test.go
+++ b/pushgw/config_test.go
@@ -1,0 +1,35 @@
+package pushgw
+
+import (
+	"github.com/exoscale/go-reporter/helpers"
+	"gopkg.in/yaml.v2"
+	"testing"
+)
+
+func TestUnmarshalConfiguration(t *testing.T) {
+	cases := []struct {
+		in   string
+		want Configuration
+	}{
+		{
+			in: `
+url: http://pushgateway.exoscale.net
+job: bar
+`,
+			want: Configuration{
+				URL: "http://pushgateway.exoscale.net",
+				Job: "bar",
+			},
+		},
+	}
+	for _, c := range cases {
+		var got Configuration
+		err := yaml.Unmarshal([]byte(c.in), &got)
+		if err != nil {
+			t.Errorf("Unmarshal(%q) error:\n%+v", c.in, err)
+		}
+		if diff := helpers.Diff(got, c.want); diff != "" {
+			t.Errorf("Unmarshal(%q) (-got +want):\n%s", c.in, diff)
+		}
+	}
+}

--- a/pushgw/root.go
+++ b/pushgw/root.go
@@ -32,7 +32,7 @@ func NewHTTPClient(config Configuration) (*http.Client, error) {
 	var tlsConfig *tls.Config
 
 	if config.CacertFile != "" {
-		cert, err := tls.LoadX509KeyPair(config.CacertFile, config.KeyFile)
+		cert, err := tls.LoadX509KeyPair(config.CertFile, config.KeyFile)
 		if err != nil {
 			return nil, errors.Wrap(err, "can't load certificate pair")
 		}

--- a/pushgw/root.go
+++ b/pushgw/root.go
@@ -2,17 +2,56 @@
 package pushgw
 
 import (
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/push"
 )
 
 // New creates a pushgateway client from configuration.
-// If URL or Job is not provided, return nil,error
-//TODO: this should return error as well and handle tls
-func New(config Configuration) *push.Pusher {
-	if config.URL == "" {
-		return nil
+func New(config Configuration) (*push.Pusher, error) {
+	if config.URL == "" || config.Job == "" {
+		return nil, nil
 	}
-	client := push.New(config.URL, config.Job)
-	return client
 
+	httpClient, err := NewHTTPClient(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "can't create http client with given config")
+	}
+
+	pwClient := push.New(config.URL, config.Job).Client(httpClient)
+	return pwClient, nil
+}
+
+// NewHTTPClient creates an http client for a given  config
+func NewHTTPClient(config Configuration) (*http.Client, error) {
+	var transport = &http.Transport{}
+	var tlsConfig *tls.Config
+
+	if config.CacertFile != "" {
+		cert, err := tls.LoadX509KeyPair(config.CacertFile, config.KeyFile)
+		if err != nil {
+			return nil, errors.Wrap(err, "can't load certificate pair")
+		}
+
+		caCert, err := ioutil.ReadFile(config.CertFile)
+		if err != nil {
+			return nil, errors.Wrap(err, "can't load certificate")
+		}
+
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCert)
+
+		tlsConfig = &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			RootCAs:      caCertPool,
+		}
+		tlsConfig.BuildNameToCertificate()
+		transport = &http.Transport{TLSClientConfig: tlsConfig}
+	}
+
+	return &http.Client{Transport: transport}, nil
 }

--- a/pushgw/root.go
+++ b/pushgw/root.go
@@ -1,0 +1,18 @@
+// Package pushgw wrapper around promethesu/push
+package pushgw
+
+import (
+	"github.com/prometheus/client_golang/prometheus/push"
+)
+
+// New creates a pushgateway client from configuration.
+// If URL or Job is not provided, return nil,error
+//TODO: this should return error as well and handle tls
+func New(config Configuration) *push.Pusher {
+	if config.URL == "" {
+		return nil
+	}
+	client := push.New(config.URL, config.Job)
+	return client
+
+}

--- a/root.go
+++ b/root.go
@@ -5,10 +5,12 @@ package reporter
 
 import (
 	"github.com/getsentry/raven-go"
+	"github.com/prometheus/client_golang/prometheus/push"
 	log "gopkg.in/inconshreveable/log15.v2"
 
 	"github.com/exoscale/go-reporter/logger"
 	"github.com/exoscale/go-reporter/metrics"
+	"github.com/exoscale/go-reporter/pushgw"
 	"github.com/exoscale/go-reporter/sentry"
 )
 
@@ -17,6 +19,7 @@ type Reporter struct {
 	logger  log.Logger
 	sentry  *raven.Client
 	metrics *metrics.Metrics
+	pushgw  *push.Pusher
 	prefix  string
 }
 
@@ -40,10 +43,17 @@ func New(config Configuration) (*Reporter, error) {
 		return nil, err
 	}
 
+	// Initialize pushgw
+	p := pushgw.New(config.Pushgw)
+	// if err != nil {
+	// 	return nil, err
+	// }
+
 	return &Reporter{
 		logger:  l,
 		sentry:  s,
 		metrics: m,
+		pushgw:  p,
 		prefix:  config.Prefix,
 	}, nil
 }

--- a/root.go
+++ b/root.go
@@ -44,10 +44,10 @@ func New(config Configuration) (*Reporter, error) {
 	}
 
 	// Initialize pushgw
-	p := pushgw.New(config.Pushgw)
-	// if err != nil {
-	// 	return nil, err
-	// }
+	p, err := pushgw.New(config.Pushgw)
+	if err != nil {
+		return nil, err
+	}
 
 	return &Reporter{
 		logger:  l,


### PR DESCRIPTION
This PR adds support for [Pushgateway](https://github.com/prometheus/pushgateway).

If there are no config entries for TLS in pushgw it will use plain http.
