### PR TITLE
Loosen Prometheus metrics configuration validation

### DIFF
--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -42,9 +42,6 @@ func (c *PrometheusConfiguration) UnmarshalYAML(unmarshal func(interface{}) erro
 	if raw.Namespace == "" {
 		return errors.Errorf("missing namespace value")
 	}
-	if raw.Subsystem == "" {
-		return errors.Errorf("missing subsystem value")
-	}
 	if raw.Interval == config.Duration(0) {
 		return errors.Errorf("missing interval value for prometheus configuration")
 	}


### PR DESCRIPTION
This change loosens up the Prometheus metrics configuration validation
by leaving the `subsystem` setting optional.