### PR TITLE
Disable caller/module info logging by default

### DIFF
--- a/logger/config.go
+++ b/logger/config.go
@@ -34,19 +34,21 @@ const (
 // The ability to override log levels for some modules is currently
 // missing.
 type Configuration struct {
-	Level   Lvl
-	Console bool
-	Syslog  bool
-	Format  LogFormat
-	Files   []LogFile
+	Level         Lvl
+	Console       bool
+	Syslog        bool
+	IncludeCaller bool `yaml:"include_caller,omitempty"`
+	Format        LogFormat
+	Files         []LogFile
 }
 
 // DefaultConfiguration is the default logging configuration.
 var DefaultConfiguration = Configuration{
-	Level:   Lvl(log.LvlInfo),
-	Console: false,
-	Syslog:  true,
-	Format:  FormatPlain,
+	Level:         Lvl(log.LvlInfo),
+	Console:       false,
+	Syslog:        true,
+	IncludeCaller: false,
+	Format:        FormatPlain,
 }
 
 // String transform a level to string.

--- a/logger/root.go
+++ b/logger/root.go
@@ -100,9 +100,7 @@ func New(config Configuration, additionalHandler log.Handler, prefix string) (lo
 		logHandler = log.MultiHandler(logHandler, additionalHandler)
 	}
 
-	if logHandler != nil {
-		logger.SetHandler(logHandler)
-	}
+	logger.SetHandler(logHandler)
 
 	return logger, nil
 }

--- a/logger/root_test.go
+++ b/logger/root_test.go
@@ -104,11 +104,11 @@ func TestNewFiles(t *testing.T) {
 	if len(lines) != 3 {
 		t.Fatalf("Got %d line of logs, expected %d", len(lines)-1, 2)
 	}
-	if !strings.Contains(string(lines[0]), " msg=hello ") {
+	if !strings.Contains(string(lines[0]), " msg=hello") {
 		t.Fatalf("First log should be %q, got %q instead",
 			"msg=hello", lines[0])
 	}
-	if !strings.Contains(string(lines[1]), " msg=important ") {
+	if !strings.Contains(string(lines[1]), " msg=important") {
 		t.Fatalf("Second log should be %q, got %q instead",
 			"msg=important", lines[1])
 	}

--- a/logger/root_test.go
+++ b/logger/root_test.go
@@ -51,6 +51,30 @@ func TestNewFiles(t *testing.T) {
 		t.Fatalf("Unable to initialize new logger:\n%+v", err)
 	}
 
+	testNewFiles(t, logger, tempDir)
+
+	logger, err = New(Configuration{
+		Level:         Lvl(log.LvlInfo),
+		IncludeCaller: true,
+		Files: []LogFile{
+			LogFile{
+				Name:   filepath.Join(tempDir, "out2.txt"),
+				Format: FormatPlain,
+			},
+			LogFile{
+				Name:   filepath.Join(tempDir, "out2.json"),
+				Format: FormatJSON,
+			},
+		},
+	}, nil, "project2")
+	if err != nil {
+		t.Fatalf("Unable to initialize new logger:\n%+v", err)
+	}
+
+	testNewFiles(t, logger, tempDir)
+}
+
+func testNewFiles(t *testing.T, logger log.Logger, tempDir string) {
 	logger.Info("hello")
 	logger.Debug("nothing")
 	logger.Crit("important")


### PR DESCRIPTION
This PR disable the caller handler in logging,

Example:
From
```
Shell
<LEVEL>[05-15|16:48:42] <message>           error="MESSAGE" caller=github.com/exoscale/go-blobd/vendor/github.com/exoscale/go-reporter/logging.go:19
```
to
```
Shell
<LEVEL>[05-15|16:48:42] <message>           error="MESSAGE"
```

to re-enable it just add `include_caller: true` in logging config

Example:
```
reporting:
  prefix: <name>
  logging:
    include_caller: true 
```