### PR TITLE
Fix linting errors

### DIFF
--- a/helpers/network.go
+++ b/helpers/network.go
@@ -10,7 +10,7 @@ import (
 func IncrementIPv4(ip net.IP, inc int) net.IP {
 	ip = ip.To4()
 	v := binary.BigEndian.Uint32(ip)
-	if v >= 0 {
+	if v >= uint32(0) {
 		v = v + uint32(inc)
 	} else {
 		v = v - uint32(-inc)

--- a/metrics/collectd_test.go
+++ b/metrics/collectd_test.go
@@ -34,7 +34,7 @@ func TestCollectd(t *testing.T) {
 	defer sock.Close()
 
 	// Initialize collectd exporter
-	var configuration Configuration = make([]ExporterConfiguration, 1, 1)
+	var configuration Configuration = make([]ExporterConfiguration, 1)
 	configuration[0] = &CollectdConfiguration{
 		Connect:  address,
 		Interval: config.Duration(500 * time.Millisecond),
@@ -87,7 +87,7 @@ L:
 	for i := 0; true; i++ {
 		select {
 		case <-deadline:
-			go m.Stop()
+			go m.Stop() // nolint: errcheck
 		case <-deadline2:
 			break L
 		case err := <-socketErr:

--- a/metrics/config.go
+++ b/metrics/config.go
@@ -23,7 +23,7 @@ func (c *Configuration) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return errors.Wrap(err, "unable to decode list of metric exporters")
 	}
 	// We now have a list of interfaces. Each interface should be a MapSlice.
-	finalConfiguration := make([]ExporterConfiguration, len(rawConfig), len(rawConfig))
+	finalConfiguration := make([]ExporterConfiguration, len(rawConfig))
 	for i, c := range rawConfig {
 		if len(c) != 1 {
 			return errors.Errorf("metric configuration item %d should contain only one element, not %d",

--- a/metrics/expvar.go
+++ b/metrics/expvar.go
@@ -54,8 +54,7 @@ func (c *ExpvarConfiguration) initExporter(metrics *Metrics) error {
 		return errors.Wrapf(err, "unable to listen to %v", address)
 	}
 	metrics.t.Go(func() error {
-		server.Serve(listener)
-		return nil
+		return server.Serve(listener)
 	})
 
 	// Handle stop correctly
@@ -63,8 +62,7 @@ func (c *ExpvarConfiguration) initExporter(metrics *Metrics) error {
 		<-metrics.t.Dying()
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		server.Shutdown(ctx)
-		return nil
+		return server.Shutdown(ctx)
 	})
 
 	return nil
@@ -101,7 +99,7 @@ func healthZ(registry metrics.Registry) func(http.ResponseWriter, *http.Request)
 			if details.Status == "fail" {
 				w.WriteHeader(542)
 			}
-			w.Write(output)
+			w.Write(output) // nolint: errcheck
 		}
 	}
 }

--- a/metrics/expvar_test.go
+++ b/metrics/expvar_test.go
@@ -29,9 +29,8 @@ func TestExpvar(t *testing.T) {
 	}
 	m.MustStart()
 	defer func() {
-		if err := m.Stop(); err != nil {
-			t.Fatal(err)
-		}
+		m.Stop() // nolint: errcheck
+
 		if !testing.Short() {
 			time.Sleep(1 * time.Second) // Slight race condition...
 			resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/", tcpPort))

--- a/metrics/file.go
+++ b/metrics/file.go
@@ -50,13 +50,12 @@ func (c *FileConfiguration) initExporter(m *Metrics) error {
 			select {
 			case <-tick.C:
 				metrics.WriteJSONOnce(m.Registry, output)
-				output.Sync()
+				output.Sync() // nolint: errcheck
 			case <-m.t.Dying():
 				break L
 			}
 		}
-		output.Close()
-		return nil
+		return output.Close()
 	})
 
 	return nil

--- a/metrics/file_test.go
+++ b/metrics/file_test.go
@@ -22,7 +22,7 @@ func TestFile(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	outputFile := filepath.Join(tempDir, "out.txt")
-	var configuration Configuration = make([]ExporterConfiguration, 1, 1)
+	var configuration Configuration = make([]ExporterConfiguration, 1)
 	configuration[0] = &FileConfiguration{
 		Interval: config.Duration(1 * time.Second),
 		Path:     config.FilePath(outputFile),
@@ -34,12 +34,14 @@ func TestFile(t *testing.T) {
 	}
 	m.MustStart()
 	defer func() {
-		m.Stop()
+		m.Stop() // nolint: errcheck
 	}()
 
 	// Increase some counter
 	c := metrics.NewCounter()
-	m.Registry.Register("foo", c)
+	if err := m.Registry.Register("foo", c); err != nil {
+		t.Fatal(err)
+	}
 	c.Inc(47)
 
 	if testing.Short() {

--- a/metrics/prompushgw.go
+++ b/metrics/prompushgw.go
@@ -74,7 +74,7 @@ func NewHTTPClient(config PromPushGWConfiguration) (*http.Client, error) {
 			Certificates: []tls.Certificate{cert},
 			RootCAs:      caCertPool,
 		}
-		tlsConfig.BuildNameToCertificate()
+		tlsConfig.BuildNameToCertificate() // nolint: staticcheck
 		transport = &http.Transport{TLSClientConfig: tlsConfig}
 	}
 

--- a/metrics/root.go
+++ b/metrics/root.go
@@ -59,7 +59,7 @@ func (m *Metrics) Start() error {
 	// Register exporters
 	for _, c := range m.config {
 		if err := c.initExporter(m); err != nil {
-			m.Stop()
+			m.Stop() // nolint: errcheck
 			return err
 		}
 	}
@@ -84,17 +84,17 @@ func (m *Metrics) Push() error {
 		case *metrics.StandardGauge:
 			g := prometheus.NewGauge(prometheus.GaugeOpts{Name: name})
 			g.Set(float64(metric.Value()))
-			registry.Register(g)
+			registry.Register(g) // nolint: errcheck
 
 		case *metrics.StandardGaugeFloat64:
 			g := prometheus.NewGauge(prometheus.GaugeOpts{Name: name})
 			g.Set(float64(metric.Value()))
-			registry.Register(g)
+			registry.Register(g) // nolint: errcheck
 
 		case *metrics.StandardCounter:
 			c := prometheus.NewCounter(prometheus.CounterOpts{Name: name})
 			c.Add(float64(metric.Count()))
-			registry.Register(c)
+			registry.Register(c) // nolint: errcheck
 		}
 	})
 


### PR DESCRIPTION
Since we have added Github action in this PR #17 , we fixed the golangci-lint cmd from travis `golangci-lint run .` to `golangci-lint run ./...` in Github Actions to lint the whole project.

